### PR TITLE
デフォルトでPCRuntimeが選択されない場合がある不具合を修正

### DIFF
--- a/lib/execjs/pcruntime.rb
+++ b/lib/execjs/pcruntime.rb
@@ -4,4 +4,4 @@ require 'execjs'
 require 'execjs/pcruntime/version'
 require 'execjs/pcruntime/runtimes'
 
-ExecJS.runtime = ExecJS::Runtimes.autodetect
+ExecJS.runtime = ExecJS::Runtimes.from_environment || ExecJS::Runtimes::PCRuntime

--- a/lib/execjs/pcruntime.rb
+++ b/lib/execjs/pcruntime.rb
@@ -3,3 +3,5 @@
 require 'execjs'
 require 'execjs/pcruntime/version'
 require 'execjs/pcruntime/runtimes'
+
+ExecJS.runtime = ExecJS::Runtimes.autodetect

--- a/lib/execjs/pcruntime/context_process_runtime.rb
+++ b/lib/execjs/pcruntime/context_process_runtime.rb
@@ -5,6 +5,7 @@ require 'tmpdir'
 require 'json'
 require 'net/protocol'
 require 'net/http'
+require 'shellwords'
 
 module ExecJS
   module PCRuntime


### PR DESCRIPTION
`ExecJS.runtime = ExecJS::Runtimes.autodetect`を入れることで、PCRuntimeが定義された状態でランタイムの選択が行われ、正常に動作するようになる

shellwordsのrequireはついでの修正