### PR TITLE
不正なUTF-8シーケンスの発生を避けるためにNode.js-Ruby間のやりとりにPercent-encodingをかける

### DIFF
--- a/lib/execjs/pcruntime/context_process_runtime.rb
+++ b/lib/execjs/pcruntime/context_process_runtime.rb
@@ -158,7 +158,10 @@ module ExecJS
           request['Connection'] = 'close'
           unless content_type.nil?
             request['Content-Type'] = content_type
-            request.body = URI.encode_uri_component(body)
+            # URI.encode_www_form_component replaces space(U+0020) into '+' (not '%20')
+            # but decodeURIComponent(in JavaScript) cannot decode '+' into space
+            # so, replace '+' into '%20'
+            request.body = URI.encode_www_form_component(body).gsub('+', '%20')
           end
 
           # Net::HTTPGenericRequest#exec

--- a/lib/execjs/pcruntime/runner.js
+++ b/lib/execjs/pcruntime/runner.js
@@ -14,16 +14,17 @@ const server = http.createServer(function (req, res) {
             req.on('data', (data) => allData += data);
             req.on('end', () => {
                 try {
-                    const result = vm.runInContext(allData, context, "(execjs)");
+                    // Percent-encoding HTTP requests and responses to avoid invalid UTF-8 sequences.
+                    const result = vm.runInContext(decodeURIComponent(allData), context, "(execjs)");
                     res.statusCode = 200;
                     res.setHeader('Content-Type', 'application/json');
-                    res.end(JSON.stringify(result), 'utf-8');
+                    res.end(encodeURIComponent(JSON.stringify(result) || null));
                 } catch (e) {
                     res.statusCode = 500;
                     res.setHeader('Content-Type', 'text/plain');
                     // to split by \0 on Ruby side
                     // see context_process_runtime.rb:179
-                    res.end(e.toString() + "\0" + (e.stack || ""));
+                    res.end(encodeURIComponent(e.toString() + "\0" + (e.stack || "")));
                 }
             });
             break;


### PR DESCRIPTION
従来実装だとごく稀に不正なUTF-8シーケンスを表すU+FFFEが混入することがあった。
おそらくTCPパケットの切れ目に起因して発生していると推測し、切れ目がどこにあっても不正なシーケンスが発生しないようPercent-encodingをかけることにした。

HTTP通信を行うライブラリの問題なのでリクエストとレスポンスのどちらかのみPercent-encodingすればよく、内部をいじれば本質的な解決も可能であると考えられるが、網羅的なテストを行うことが難しいため多少のオーバーヘッドを許容して確実な回避策を採用する。