### PR TITLE
並行実行可能なスレッド数を制限 & 外部プロセス由来のエラー時にリトライ

### DIFF
--- a/lib/execjs/pcruntime/context_process_runtime.rb
+++ b/lib/execjs/pcruntime/context_process_runtime.rb
@@ -211,7 +211,9 @@ module ExecJS
         @runner_path = runner_path
         @binary = nil
         @deprecated = deprecated
-        @semaphore = Semaphore.new 100
+        # macOS limits the number of file descriptors 256,
+        # so, set semaphore limit half of it
+        @semaphore = Semaphore.new 128
       end
 
       # implementation of ExecJS::Runtime#available?

--- a/lib/execjs/pcruntime/context_process_runtime.rb
+++ b/lib/execjs/pcruntime/context_process_runtime.rb
@@ -250,8 +250,7 @@ module ExecJS
         @runner_path = runner_path
         @binary = nil
         @deprecated = deprecated
-        # macOS limits the number of file descriptors 256,
-        # so, set semaphore limit half of it
+        # limit number of threads 128 to avoid Errno::ECONNREFUSED
         @semaphore = Semaphore.new 128
       end
 


### PR DESCRIPTION
### 並列実行可能なスレッド数を制限
10,000スレッドぐらいから同時にcontext.evalを呼ぶとErrno::ECONNREFUSEDのエラーが出る
実用上10,000並列で呼び出したいことはほぼ無さそうなので、並列実行可能数に制限をかけることで回避したい

TODO:
- [x] Semaphoreの実装をどうするか
  - 現実装はThread::Queueだが、これは目的外使用という感じなのでできれば避けたい
  - concurrent-rubyにSemaphoreがあるが、これだけのために依存を増やすべきかどうか(どうせSprocketsなどで使っているので良いというのはある)
  - ConditionVariableで自前実装は可能だが、それはそれでリスクがある
  - concurrent-rubyのSemaphore、ConditionVariableでの自前実装を試したが、Thread::Queueを使ったものが一番速かったのでこれにする
- [x] 同時実行可能数の制限をどうするか
  - 現実装では適当に100で固定
  - せめて何らかの根拠に基づいた値にしたい
  - macOSでは単一プロセスが開けるファイルディスクリプタの数が最大256らしいので、その半分に制限するようにした

### 外部プロセス由来のエラー時にリトライ
現状、実行中にNode.jsのプロセスが何らかの理由で落ちたりSocketが閉じたりするとそのままRuby側も落ちる実装になっている
execjsデフォルトのNode.jsランタイムなどではexec毎にプロセスを起動しているのでこのような予期しない問題はほぼ起きないが、pcruntimeのように単一のプロセスを長時間使い回す実装ではこのような問題が起こる確率が比較的高いため、もしも起こった場合のリトライ処理を実装した