### PR TITLE
依存関係の更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ end
 
 group :test do
   gem 'minitest', '~> 5.0'
-  gem 'rake', '~> 12.0'
+  gem 'rake', '~> 13.0'
 end

--- a/execjs-pcruntime.gemspec
+++ b/execjs-pcruntime.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'execjs-pcruntime'
   spec.version       = Execjs::PCRuntime::VERSION
   spec.authors       = ['White-Green']
-  spec.required_ruby_version = '>=3.0.0'
+  spec.required_ruby_version = '>=3.1.0'
   spec.summary       = 'Fast ExecJS Runtime using Process as a Context.'
   spec.homepage      = 'https://rubygems.org/gems/execjs-pcruntime'
   spec.license       = 'MIT'


### PR DESCRIPTION
- テスト用のworkflowからRuby 3.0を外したので`required_ruby_version`を3.1に
- なぜか古いバージョンを使っていたrakeを13に更新