### PR TITLE
Version 0.3.0

### DIFF
--- a/lib/execjs/pcruntime/version.rb
+++ b/lib/execjs/pcruntime/version.rb
@@ -2,6 +2,6 @@
 
 module Execjs
   module PCRuntime
-    VERSION = '0.2.2'
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
変更点は #9 #11 
#11 でRuby 3.0をサポート外としたため、非互換な変更であるとしてバージョンを0.3とする