### PR TITLE
Ruby 3.4を使うようにする

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
       - name: Install dependencies
         run: bundle install
       - name: Run RuboCop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.3', '3.2', '3.1']
+        ruby-version: ['3.4', '3.3', '3.2', '3.1']
         node-version: ['16', '18', '20', '22']
 
     steps:


### PR DESCRIPTION
2024/12/25にRuby 3.4.0がリリースされました
本リポジトリでもCIでのテストなどでRuby 3.4を使うようにします