### PR TITLE
security: add Takumi Guard for RubyGems

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,9 +10,14 @@ jobs:
   rubocop:
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
+      - uses: flatt-security/setup-takumi-guard-rubygems@v1
+        with:
+          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,14 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: heyinc/setup-ruby-with-takumi-guard@v1
         with:
+          working-directory: .
+          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
           ruby-version: '3.4'
-      - uses: flatt-security/setup-takumi-guard-rubygems@v1
-        with:
-          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
-      - name: Install dependencies
-        run: bundle install
       - name: Run RuboCop
         run: bundle exec rubocop

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: flatt-security/setup-takumi-guard-rubygems@v1
-        with:
-          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'
+      - uses: flatt-security/setup-takumi-guard-rubygems@v1
+        with:
+          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
       - name: Install dependencies
         run: bundle install
       - name: Run RuboCop

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,10 +15,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: heyinc/setup-ruby-with-takumi-guard@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          working-directory: .
-          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
           ruby-version: '3.4'
+      - uses: flatt-security/setup-takumi-guard-rubygems@v1
+        with:
+          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
+      - name: Install dependencies
+        run: bundle install
       - name: Run RuboCop
         run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     strategy:
       matrix:
@@ -18,6 +20,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: flatt-security/setup-takumi-guard-rubygems@v1
+        with:
+          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: flatt-security/setup-takumi-guard-rubygems@v1
-        with:
-          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+      - uses: flatt-security/setup-takumi-guard-rubygems@v1
+        with:
+          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,18 +20,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+      - uses: heyinc/setup-ruby-with-takumi-guard@v1
         with:
+          working-directory: .
+          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
           ruby-version: ${{ matrix.ruby-version }}
-      - uses: flatt-security/setup-takumi-guard-rubygems@v1
-        with:
-          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
+          cache-key-extra: node-${{ matrix.node-version }}
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,15 +20,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: heyinc/setup-ruby-with-takumi-guard@v1
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
         with:
-          working-directory: .
-          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
           ruby-version: ${{ matrix.ruby-version }}
-          cache-key-extra: node-${{ matrix.node-version }}
+      - uses: flatt-security/setup-takumi-guard-rubygems@v1
+        with:
+          bot-id: "${{ vars.TAKUMI_GUARD_BOT_ID }}"
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: bundle install
       - name: Run tests
         run: bundle exec rake


### PR DESCRIPTION
## 変更内容
- `flatt-security/setup-takumi-guard-rubygems@v1` を CI に追加し、rubygems.org からの gem 取得を Takumi Guard プロキシ経由にする
- Private gem (`pkg.stin.cc` 等) は Gemfile の source ブロック分離によりプロキシをバイパスするため変更不要

## 確認方法
- CI が正常に通ること
- `bundle install` のログに `rubygems.flatt.tech` が表示されること

> 依頼元: https://github.com/heyinc/tech-drive/issues/1185

🤖 Generated with Kuro

:link: Quest: https://kuro.stin.cc/#/quests/20260513-143337-bkjutm